### PR TITLE
SpeedIndex: sum from first paint, rather than 0

### DIFF
--- a/src/speed-index.js
+++ b/src/speed-index.js
@@ -115,7 +115,7 @@ function calculateSpeedIndexes(frames, data) {
 
 	frames.forEach(function (frame) {
 		// skip frames from 0 to fP
-		if (frame.getTimeStamp() >= firstPaintTs) {
+		if (frame.getTimeStamp() > firstPaintTs) {
 			const elapsed = frame.getTimeStamp() - prevFrameTs;
 			speedIndex += elapsed * (1 - prevProgress);
 			perceptualSpeedIndex += elapsed * (1 - prevPerceptualProgress);

--- a/src/speed-index.js
+++ b/src/speed-index.js
@@ -114,9 +114,12 @@ function calculateSpeedIndexes(frames, data) {
 	let perceptualSpeedIndex = firstPaintTs - startTs;
 
 	frames.forEach(function (frame) {
-		const elapsed = frame.getTimeStamp() - prevFrameTs;
-		speedIndex += elapsed * (1 - prevProgress);
-		perceptualSpeedIndex += elapsed * (1 - prevPerceptualProgress);
+		// skip frames from 0 to fP
+		if (frame.getTimeStamp() >= firstPaintTs) {
+			const elapsed = frame.getTimeStamp() - prevFrameTs;
+			speedIndex += elapsed * (1 - prevProgress);
+			perceptualSpeedIndex += elapsed * (1 - prevPerceptualProgress);
+		}
 
 		prevFrameTs = frame.getTimeStamp();
 		prevProgress = frame.getProgress() / 100;

--- a/test/speed-index.js
+++ b/test/speed-index.js
@@ -51,8 +51,8 @@ test('speed index calculate the right value', async t => {
 	]);
 
 	const indexes = speedIndex.calculateSpeedIndexes(data.frames, data);
-	t.is(indexes.speedIndex, 2000);
-	t.is(indexes.perceptualSpeedIndex, 2000);
+	t.is(indexes.speedIndex, 1000);
+	t.is(indexes.perceptualSpeedIndex, 1000);
 });
 
 test('speed indexes calculated for trace w/ 1 frame @ 4242ms', async t => {
@@ -60,8 +60,8 @@ test('speed indexes calculated for trace w/ 1 frame @ 4242ms', async t => {
 	speedIndex.calculateVisualProgress(data.frames);
 	speedIndex.calculatePerceptualProgress(data.frames);
 	const indexes = speedIndex.calculateSpeedIndexes(data.frames, data);
-	t.is(Math.floor(indexes.speedIndex), 8484);
-	t.is(Math.floor(indexes.perceptualSpeedIndex), 8484);
+	t.is(Math.floor(indexes.speedIndex), 4242);
+	t.is(Math.floor(indexes.perceptualSpeedIndex), 4242);
 });
 
 test('speed indexes calculated for 2 frame (blank @1s, content @ 2s) trace', async t => {
@@ -69,8 +69,8 @@ test('speed indexes calculated for 2 frame (blank @1s, content @ 2s) trace', asy
 	speedIndex.calculateVisualProgress(data.frames);
 	speedIndex.calculatePerceptualProgress(data.frames);
 	const indexes = speedIndex.calculateSpeedIndexes(data.frames, data);
-	t.is(Math.floor(indexes.speedIndex), 2980);
-	t.is(Math.floor(indexes.perceptualSpeedIndex), 2805);
+	t.is(Math.floor(indexes.speedIndex), 1980);
+	t.is(Math.floor(indexes.perceptualSpeedIndex), 2000);
 });
 
 test('speed indexes calculated for 2 frame (content @1s, more content @2s) trace', async t => {
@@ -78,8 +78,8 @@ test('speed indexes calculated for 2 frame (content @1s, more content @2s) trace
 	speedIndex.calculateVisualProgress(data.frames);
 	speedIndex.calculatePerceptualProgress(data.frames);
 	const indexes = speedIndex.calculateSpeedIndexes(data.frames, data);
-	t.is(Math.floor(indexes.speedIndex), 2040);
-	t.is(Math.floor(indexes.perceptualSpeedIndex), 2066);
+	t.is(Math.floor(indexes.speedIndex), 1040);
+	t.is(Math.floor(indexes.perceptualSpeedIndex), 1066);
 });
 
 test('speed indexes calculated for 3 frame (blank @1s, content @2s, more content @3s) trace', async t => {
@@ -87,7 +87,7 @@ test('speed indexes calculated for 3 frame (blank @1s, content @2s, more content
 	speedIndex.calculateVisualProgress(data.frames);
 	speedIndex.calculatePerceptualProgress(data.frames);
 	const indexes = speedIndex.calculateSpeedIndexes(data.frames, data);
-	t.is(Math.floor(indexes.speedIndex), 3040);
-	t.is(Math.floor(indexes.perceptualSpeedIndex), 3066);
+	t.is(Math.floor(indexes.speedIndex), 2040);
+	t.is(Math.floor(indexes.perceptualSpeedIndex), 2066);
 });
 

--- a/test/speed-index.js
+++ b/test/speed-index.js
@@ -91,3 +91,58 @@ test('speed indexes calculated for 3 frame (blank @1s, content @2s, more content
 	t.is(Math.floor(indexes.perceptualSpeedIndex), 2066);
 });
 
+test('speed index starts summing from first paint', async t => {
+
+	const mockData = getMockProgessFrames();
+	/**
+	 *  We've generated frames with this visual progress curve (0, 0, 25, 75, 100)
+	 *
+	 *      ___________________________________________________
+	 *  100 |░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░████████
+	 *   75 |░░░░░░░░░░░░░░░░░░░░░░░░▄▄▄▄▄▄▄████████
+	 *   50 |░░░░░░░░░░░░░░░░░░░░░░░░███████████████
+	 *   25 |░░░░░░░░░░░░░░░░▄▄▄▄▄▄▄▄███████████████
+	 *    0 |░░░░░░░░░░░░░░░░███████████████████████
+	 *      ----------|----------|---------|---------|---------
+	 *      0         1000      2000      3000      4000
+	 *
+	 *	Speed Index is the area above the curve. Second by second:
+	 *         1000    +  1000   +   750  +   250   +    0
+	 *  Our total sum, and thus our Speed Index, is 3000.
+	 */
+
+	const indexes = speedIndex.calculateSpeedIndexes(mockData.frames, mockData.data);
+
+	t.is(Math.floor(indexes.speedIndex), 3000);
+	t.is(Math.floor(indexes.perceptualSpeedIndex), 3000);
+});
+
+function getMockProgessFrames() {
+
+	// first two frames show no movement
+	const f0 = frame.create(null, 0);
+	const f1 = frame.create(null, 1000);
+	f0.setPerceptualProgress(0);
+	f1.setPerceptualProgress(0);
+	f0.setProgress(0);
+	f1.setProgress(0);
+	// f2 at 2s is first paint  (25% vc)
+	const f2 = frame.create(null, 2000);
+	f2.setPerceptualProgress(25);
+	f2.setProgress(25);
+	// f3 at 3s fleshes it out (75% vc)
+	const f3 = frame.create(null, 3000);
+	f3.setPerceptualProgress(75);
+	f3.setProgress(75);
+	// f4 at 4s completes things (100% vc)
+	const f4 = frame.create(null, 4000);
+	f4.setPerceptualProgress(100);
+	f4.setProgress(100);
+
+	const frames = [f0, f1, f2, f3, f4];
+	const data = { startTs: 0 };
+	return {
+		frames,
+		data
+	}
+}

--- a/test/speed-index.js
+++ b/test/speed-index.js
@@ -92,33 +92,30 @@ test('speed indexes calculated for 3 frame (blank @1s, content @2s, more content
 });
 
 test('speed index starts summing from first paint', async t => {
-
 	const mockData = getMockProgessFrames();
 	/**
 	 *  We've generated frames with this visual progress curve (0, 0, 25, 75, 100)
 	 *
 	 *      ___________________________________________________
-	 *  100 |░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░████████
-	 *   75 |░░░░░░░░░░░░░░░░░░░░░░░░▄▄▄▄▄▄▄████████
-	 *   50 |░░░░░░░░░░░░░░░░░░░░░░░░███████████████
-	 *   25 |░░░░░░░░░░░░░░░░▄▄▄▄▄▄▄▄███████████████
-	 *    0 |░░░░░░░░░░░░░░░░███████████████████████
+	 *  100 |░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░██████████
+	 *   75 |░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░▄▄▄▄▄▄▄▄▄▄██████████
+	 *   50 |░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░████████████████████
+	 *   25 |░░░░░░░░░░░░░░░░░░░░▄▄▄▄▄▄▄▄▄▄████████████████████
+	 *    0 |░░░░░░░░░░░░░░░░░░░░██████████████████████████████
 	 *      ----------|----------|---------|---------|---------
 	 *      0         1000      2000      3000      4000
 	 *
-	 *	Speed Index is the area above the curve. Second by second:
-	 *         1000    +  1000   +   750  +   250   +    0
+	 *	Speed Index is the area above the curve (goo.gl/0YZ7TP). Second by second:
+	 *          1000    +  1000   +   750  +   250   +   0
 	 *  Our total sum, and thus our Speed Index, is 3000.
 	 */
 
 	const indexes = speedIndex.calculateSpeedIndexes(mockData.frames, mockData.data);
-
 	t.is(Math.floor(indexes.speedIndex), 3000);
 	t.is(Math.floor(indexes.perceptualSpeedIndex), 3000);
 });
 
 function getMockProgessFrames() {
-
 	// first two frames show no movement
 	const f0 = frame.create(null, 0);
 	const f1 = frame.create(null, 1000);
@@ -140,9 +137,9 @@ function getMockProgessFrames() {
 	f4.setProgress(100);
 
 	const frames = [f0, f1, f2, f3, f4];
-	const data = { startTs: 0 };
+	const data = {startTs: 0};
 	return {
 		frames,
 		data
-	}
+	};
 }

--- a/test/speed-index.js
+++ b/test/speed-index.js
@@ -87,7 +87,7 @@ test('speed indexes calculated for 3 frame (blank @1s, content @2s, more content
 	speedIndex.calculateVisualProgress(data.frames);
 	speedIndex.calculatePerceptualProgress(data.frames);
 	const indexes = speedIndex.calculateSpeedIndexes(data.frames, data);
-	t.is(Math.floor(indexes.speedIndex), 4040);
-	t.is(Math.floor(indexes.perceptualSpeedIndex), 4066);
+	t.is(Math.floor(indexes.speedIndex), 3040);
+	t.is(Math.floor(indexes.perceptualSpeedIndex), 3066);
 });
 


### PR DESCRIPTION
My large updated changed the SI calculation but it slipped up on one detail. ☔ 
As [Parvez described here](https://github.com/pmdartus/speedline/issues/28#issuecomment-244127192), SI is `fP + sum(fP to VC){1-VC%}`, but I had (effectively) `sum(0 to VC)` in the middle there.

We need to sum the perceptual progress costs starting from first paint, so we don't double-count the delta from 0 to FP. 
