### PR TITLE
Trace fixtures have clear timestamps

### DIFF
--- a/test/assets/oneframe-content.json
+++ b/test/assets/oneframe-content.json
@@ -1,10 +1,9 @@
-
-  {
+{
     "traceEvents": [
       {
         "pid": 74921,
         "tid": 1295,
-        "ts": 944612274374,
+        "ts": 80000000000,
         "ph": "X",
         "cat": "toplevel",
         "name": "MessageLoop::RunTask",
@@ -19,7 +18,7 @@
       {
         "pid": 93267,
         "tid": 1295,
-        "ts": 944612589368,
+        "ts": 80004242000,
         "ph": "O",
         "cat": "disabled-by-default-devtools.screenshot",
         "name": "Screenshot",
@@ -32,7 +31,7 @@
       {
         "pid": 93267,
         "tid": 40963,
-        "ts": 944613048925,
+        "ts": 800082424000,
         "ph": "X",
         "cat": "ipc,toplevel",
         "name": "ChannelMojo::OnMessageReceived",
@@ -71,4 +70,4 @@
       "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2831.0 Safari/537.36",
       "v8-version": "5.4.437"
     }
-  }
+}

--- a/test/assets/threeframes-blank_content_more.json
+++ b/test/assets/threeframes-blank_content_more.json
@@ -3,7 +3,7 @@
 			{
 				"pid": 93449,
 				"tid": 1295,
-				"ts": 960431276975,
+				"ts": 900000000000,
 				"ph": "X",
 				"cat": "toplevel",
 				"name": "MessageLoop::RunTask",
@@ -18,7 +18,7 @@
 			{
 				"pid": 93267,
 				"tid": 1295,
-				"ts": 960431336333,
+				"ts": 900001000000,
 				"ph": "O",
 				"cat": "disabled-by-default-devtools.screenshot",
 				"name": "Screenshot",
@@ -31,7 +31,7 @@
 			{
 				"pid": 93267,
 				"tid": 1295,
-				"ts": 960432073662,
+				"ts": 900002000000,
 				"ph": "O",
 				"cat": "disabled-by-default-devtools.screenshot",
 				"name": "Screenshot",
@@ -44,7 +44,7 @@
 			{
 				"pid": 93267,
 				"tid": 1295,
-				"ts": 960434262134,
+				"ts": 900003000000,
 				"ph": "O",
 				"cat": "disabled-by-default-devtools.screenshot",
 				"name": "Screenshot",
@@ -57,7 +57,7 @@
 			{
 				"pid": 93267,
 				"tid": 1295,
-				"ts": 960434762288,
+				"ts": 900004000000,
 				"ph": "X",
 				"cat": "toplevel",
 				"name": "MessageLoop::RunTask",

--- a/test/assets/twoframes-blank_content.json
+++ b/test/assets/twoframes-blank_content.json
@@ -3,7 +3,7 @@
 			{
 				"pid": 93449,
 				"tid": 1295,
-				"ts": 960431276975,
+				"ts": 900000000000,
 				"ph": "X",
 				"cat": "toplevel",
 				"name": "MessageLoop::RunTask",
@@ -18,7 +18,7 @@
 			{
 				"pid": 93267,
 				"tid": 1295,
-				"ts": 960431336333,
+				"ts": 900001000000,
 				"ph": "O",
 				"cat": "disabled-by-default-devtools.screenshot",
 				"name": "Screenshot",
@@ -31,7 +31,7 @@
 			{
 				"pid": 93267,
 				"tid": 1295,
-				"ts": 960434262134,
+				"ts": 900002000000,
 				"ph": "O",
 				"cat": "disabled-by-default-devtools.screenshot",
 				"name": "Screenshot",
@@ -44,7 +44,7 @@
 			{
 				"pid": 93267,
 				"tid": 1295,
-				"ts": 960434762288,
+				"ts": 900003000000,
 				"ph": "X",
 				"cat": "toplevel",
 				"name": "MessageLoop::RunTask",

--- a/test/assets/twoframes-content_more.json
+++ b/test/assets/twoframes-content_more.json
@@ -3,7 +3,7 @@
       {
         "pid": 93449,
         "tid": 1295,
-        "ts": 960431276975,
+        "ts": 900000000000,
         "ph": "X",
         "cat": "toplevel",
         "name": "MessageLoop::RunTask",
@@ -18,7 +18,7 @@
       {
         "pid": 93267,
         "tid": 1295,
-        "ts": 960432073662,
+        "ts": 900001000000,
         "ph": "O",
         "cat": "disabled-by-default-devtools.screenshot",
         "name": "Screenshot",
@@ -31,7 +31,7 @@
       {
         "pid": 93267,
         "tid": 1295,
-        "ts": 960434262134,
+        "ts": 900002000000,
         "ph": "O",
         "cat": "disabled-by-default-devtools.screenshot",
         "name": "Screenshot",
@@ -44,7 +44,7 @@
       {
         "pid": 93267,
         "tid": 1295,
-        "ts": 960434762288,
+        "ts": 900003000000,
         "ph": "X",
         "cat": "toplevel",
         "name": "MessageLoop::RunTask",

--- a/test/speed-index.js
+++ b/test/speed-index.js
@@ -60,8 +60,8 @@ test('speed indexes calculated for trace w/ 1 frame @ 4242ms', async t => {
 	speedIndex.calculateVisualProgress(data.frames);
 	speedIndex.calculatePerceptualProgress(data.frames);
 	const indexes = speedIndex.calculateSpeedIndexes(data.frames, data);
-	t.is(Math.floor(indexes.speedIndex), 629);
-	t.is(Math.floor(indexes.perceptualSpeedIndex), 629);
+	t.is(Math.floor(indexes.speedIndex), 8484);
+	t.is(Math.floor(indexes.perceptualSpeedIndex), 8484);
 });
 
 test('speed indexes calculated for 2 frame (blank @1s, content @ 2s) trace', async t => {
@@ -69,8 +69,8 @@ test('speed indexes calculated for 2 frame (blank @1s, content @ 2s) trace', asy
 	speedIndex.calculateVisualProgress(data.frames);
 	speedIndex.calculatePerceptualProgress(data.frames);
 	const indexes = speedIndex.calculateSpeedIndexes(data.frames, data);
-	t.is(Math.floor(indexes.speedIndex), 2986);
-	t.is(Math.floor(indexes.perceptualSpeedIndex), 3032);
+	t.is(Math.floor(indexes.speedIndex), 2980);
+	t.is(Math.floor(indexes.perceptualSpeedIndex), 2805);
 });
 
 test('speed indexes calculated for 2 frame (content @1s, more content @2s) trace', async t => {
@@ -78,8 +78,8 @@ test('speed indexes calculated for 2 frame (content @1s, more content @2s) trace
 	speedIndex.calculateVisualProgress(data.frames);
 	speedIndex.calculatePerceptualProgress(data.frames);
 	const indexes = speedIndex.calculateSpeedIndexes(data.frames, data);
-	t.is(Math.floor(indexes.speedIndex), 1680);
-	t.is(Math.floor(indexes.perceptualSpeedIndex), 1738);
+	t.is(Math.floor(indexes.speedIndex), 2040);
+	t.is(Math.floor(indexes.perceptualSpeedIndex), 2066);
 });
 
 test('speed indexes calculated for 3 frame (blank @1s, content @2s, more content @3s) trace', async t => {
@@ -87,7 +87,7 @@ test('speed indexes calculated for 3 frame (blank @1s, content @2s, more content
 	speedIndex.calculateVisualProgress(data.frames);
 	speedIndex.calculatePerceptualProgress(data.frames);
 	const indexes = speedIndex.calculateSpeedIndexes(data.frames, data);
-	t.is(Math.floor(indexes.speedIndex), 1680);
-	t.is(Math.floor(indexes.perceptualSpeedIndex), 1738);
+	t.is(Math.floor(indexes.speedIndex), 4040);
+	t.is(Math.floor(indexes.perceptualSpeedIndex), 4066);
 });
 

--- a/test/speed-index.js
+++ b/test/speed-index.js
@@ -55,7 +55,7 @@ test('speed index calculate the right value', async t => {
 	t.is(indexes.perceptualSpeedIndex, 2000);
 });
 
-test('speed indexes calculated for 1 frame traces', async t => {
+test('speed indexes calculated for trace w/ 1 frame @ 4242ms', async t => {
 	const data = await frame.extractFramesFromTimeline('./assets/oneframe-content.json');
 	speedIndex.calculateVisualProgress(data.frames);
 	speedIndex.calculatePerceptualProgress(data.frames);
@@ -64,7 +64,7 @@ test('speed indexes calculated for 1 frame traces', async t => {
 	t.is(Math.floor(indexes.perceptualSpeedIndex), 629);
 });
 
-test('speed indexes calculated for 2 frame (blank, content) traces', async t => {
+test('speed indexes calculated for 2 frame (blank @1s, content @ 2s) trace', async t => {
 	const data = await frame.extractFramesFromTimeline('./assets/twoframes-blank_content.json');
 	speedIndex.calculateVisualProgress(data.frames);
 	speedIndex.calculatePerceptualProgress(data.frames);
@@ -73,7 +73,7 @@ test('speed indexes calculated for 2 frame (blank, content) traces', async t => 
 	t.is(Math.floor(indexes.perceptualSpeedIndex), 3032);
 });
 
-test('speed indexes calculated for 2 frame (content, more content) traces', async t => {
+test('speed indexes calculated for 2 frame (content @1s, more content @2s) trace', async t => {
 	const data = await frame.extractFramesFromTimeline('./assets/twoframes-content_more.json');
 	speedIndex.calculateVisualProgress(data.frames);
 	speedIndex.calculatePerceptualProgress(data.frames);
@@ -82,7 +82,7 @@ test('speed indexes calculated for 2 frame (content, more content) traces', asyn
 	t.is(Math.floor(indexes.perceptualSpeedIndex), 1738);
 });
 
-test('speed indexes calculated for 3 frame (blank, content, more content) traces', async t => {
+test('speed indexes calculated for 3 frame (blank @1s, content @2s, more content @3s) trace', async t => {
 	const data = await frame.extractFramesFromTimeline('./assets/threeframes-blank_content_more.json');
 	speedIndex.calculateVisualProgress(data.frames);
 	speedIndex.calculatePerceptualProgress(data.frames);


### PR DESCRIPTION
While working on #33 it's clear that the fairly arbitrary timestamps in the test traces make it hard to validate results (and see the bug that was present).

This change has no functional effect, but makes it much easier to validate the expected SI results. 

The results below for `speed indexes calculated for trace w/ 1 frame @ 4242ms` already arise some suspicions. :) I'll be addressing those back in #33.
