### PR TITLE
decode images only once per frame

### DIFF
--- a/src/frame.js
+++ b/src/frame.js
@@ -108,6 +108,7 @@ function frame(imgBuff, ts) {
 	let _histogram = null;
 	let _progress = null;
 	let _perceptualProgress = null;
+	let _parsedImage = null;
 
 	return {
 		getHistogram: function () {
@@ -115,7 +116,7 @@ function frame(imgBuff, ts) {
 				return _histogram;
 			}
 
-			const pixels = jpeg.decode(imgBuff);
+			const pixels = this.getParsedImage();
 			_histogram = convertPixelsToHistogram(pixels);
 			return _histogram;
 		},
@@ -137,7 +138,10 @@ function frame(imgBuff, ts) {
 		},
 
 		getParsedImage: function () {
-			return jpeg.decode(imgBuff);
+			if (!_parsedImage) {
+				_parsedImage = jpeg.decode(imgBuff);
+			}
+			return _parsedImage;
 		},
 
 		getProgress: function () {


### PR DESCRIPTION
I noticed in a profile that the lion's share of execution time for a decent sized trace is going to `jpeg.decode()`. It appears that `decode` is called twice per frame (once for visual, once for perceptual), and the last frame is also decoded once per every other frame (for comparison in `calculateFrameSimilarity`), a total of ~3*framecount `decode`s.

A quick non-invasive fix (ignoring #29 :) is to make sure the decode is only done once per frame. Not all decodes are equivalent in execution time, but caching the decoded image brings the decode portion of the run down to about a third of the current time, plus it relieves some GC pressure.

Bottom-up profile (from inside a Lighthouse run) sorted by total time before:
<img width="402" alt="screen shot 2016-10-07 at 16 19 32" src="https://cloud.githubusercontent.com/assets/316891/19207977/026c007c-8caa-11e6-8128-45621186dba5.png">

and after:
<img width="390" alt="screen shot 2016-10-07 at 16 23 40" src="https://cloud.githubusercontent.com/assets/316891/19208028/76bfa898-8caa-11e6-9a38-4e0a9e47d48a.png">

Using command line `speedline`, averaging several runs over a single trace of `www.chromestatus.com` with 85 frames, total execution time dropped about 45%, from ~7.2s to ~3.9s

Caching is done inside `frame`, similar to the internal `_histogram` cache, but let me know if a different spot would be better.
