### PR TITLE
Add timeOrigin option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,9 +58,10 @@ speedline('./timeline').then(results => {
 
 ### API
 
-#### `speedline(timeline)`
+#### `speedline(timeline [, opts])`
 
 * (string | object[]) `timeline`
+* (object) `opts`
 * returns (Promise) resolving with an object containing:
   * `beginning` (number) - Recording start timestamp    
   * `end` (number) - Recording end timestamp
@@ -74,6 +75,10 @@ speedline('./timeline').then(results => {
 If the type of the timeline parameter is:
 * `string` - the parameter represents the location of the of file containing the timeline.
 * `array` - the parameter represents the traceEvents content of the timeline file.
+
+`opts`
+* `timeOrigin`: Provides the baseline timeStamp, typically navigationStart. Must be a monotonic clock timestamp that matches the trace.  E.g. `speedline('trace.json', {timeOrigin: 103205446186})`
+
 
 #### `Frame`
 

--- a/src/frame.js
+++ b/src/frame.js
@@ -66,7 +66,8 @@ function synthesizeWhiteFrame(frames) {
 }
 
 const screenshotTraceCategory = 'disabled-by-default-devtools.screenshot';
-function extractFramesFromTimeline(timeline) {
+function extractFramesFromTimeline(timeline, opts) {
+	opts = opts || {};
 	let trace;
 	trace = typeof timeline === 'string' ? fs.readFileSync(timeline, 'utf-8') : timeline;
 	try {
@@ -77,7 +78,7 @@ function extractFramesFromTimeline(timeline) {
 	let events = trace.traceEvents || trace;
 	events = events.sort((a, b) => a.ts - b.ts).filter(e => e.ts !== 0);
 
-	const startTs = events[0].ts / 1000;
+	const startTs = (opts.timeOrigin || events[0].ts) / 1000;
 	const endTs = events[events.length - 1].ts / 1000;
 
 	const rawScreenshots = events.filter(e => e.cat.includes(screenshotTraceCategory));

--- a/src/index.js
+++ b/src/index.js
@@ -24,10 +24,11 @@ function calculateValues(frames, data) {
 /**
  * Retrieve speed index informations
  * @param  {string|Array|DevtoolsTimelineModel} timeline
+ * @param  {?Object} opts
  * @return {Promise} resolving with an object containing the speed index informations
  */
-module.exports = function (timeline) {
-	return frame.extractFramesFromTimeline(timeline).then(function (data) {
+module.exports = function (timeline, opts) {
+	return frame.extractFramesFromTimeline(timeline, opts).then(function (data) {
 		const frames = data.frames;
 		speedIndex.calculateVisualProgress(frames);
 		speedIndex.calculatePerceptualProgress(frames);

--- a/test/frame.js
+++ b/test/frame.js
@@ -37,7 +37,7 @@ test('frames can set and retrieve progress', t => {
 
 test('extract frames from timeline should return a data object with an array of frames', async t => {
 	const data = await frame.extractFramesFromTimeline('./assets/nyt.json');
-	t.truthy(data.startTs, 'data.startTs doesn\'t exist');
+	t.is(data.startTs, 282644630.041, 'data.startTs doesn\'t match expected value');
 	t.truthy(data.endTs, 'data.endTs doesn\'t exist');
 	t.true(Array.isArray(data.frames), 'Frames is not an array');
 });
@@ -45,5 +45,13 @@ test('extract frames from timeline should return a data object with an array of 
 test('extract frames should support json', async t => {
 	const trace = JSON.parse(fs.readFileSync('./assets/progressive-app.json', 'utf-8'));
 	const data = await frame.extractFramesFromTimeline(trace);
+	t.is(data.startTs, 103204916.772, 'data.startTs doesn\'t match expected value');
+	t.true(Array.isArray(data.frames), 'Frames is not an array');
+});
+
+test('extract frames from timeline supports options', async t => {
+	const data = await frame.extractFramesFromTimeline('./assets/progressive-app.json', {timeOrigin: 103205446186});
+	t.is(data.startTs, 103205446.186, 'data.startTs doesn\'t match supplied timeOrigin value');
+	t.truthy(data.endTs, 'data.endTs doesn\'t exist');
 	t.true(Array.isArray(data.frames), 'Frames is not an array');
 });

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ import speedline from '../';
 
 const TIMELINE_PATH = path.join(__dirname, 'assets/progressive-app.json');
 
-test('speedline return object should contain timming informations', async t => {
+test('speedline return object should contain timing informations', async t => {
 	const results = await speedline(TIMELINE_PATH);
 	t.is(typeof results.first, 'number');
 	t.is(typeof results.complete, 'number');
@@ -14,6 +14,13 @@ test('speedline return object should contain timming informations', async t => {
 test('speedline return object should contain speed index', async t => {
 	const results = await speedline(TIMELINE_PATH);
 	t.is(typeof results.speedIndex, 'number');
+	t.is(Math.floor(results.speedIndex), 1133);
+});
+
+test('speedline can takes timeOrigin option and adjusts results', async t => {
+	const results = await speedline(TIMELINE_PATH, {timeOrigin: 103205446186});
+	t.is(typeof results.speedIndex, 'number');
+	t.is(Math.floor(results.speedIndex), 604);
 });
 
 test('speedline return object should contain frames informations', async t => {


### PR DESCRIPTION
fixes #27 

The number is a monotonic clock timestamp (consistent with timestamps in the trace).
The number I'm using for progressive-app.json is the navigationStart of the tab and frame. 

