### PR TITLE
feat: add --fast mode

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -80,6 +80,7 @@ var cli = meow([
 	'Options',
 	'  -p, --pretty  Pretty print the output',
 	'  --fast  Skip parsing frames between similar ones',
+	'          DISCLAIMER: may result in different metrics due to skipped frames',
 	'',
 	'Examples',
 	'  $ speedline ./timeline.json'
@@ -91,6 +92,10 @@ if (cli.input.length !== 1) {
 }
 
 var filePath = path.resolve(process.cwd(), cli.input[0]);
+
+if (cli.flags.fast) {
+	console.warn('WARNING: using --fast may result in different metrics due to skipped frames');
+}
 
 speedIndex(filePath, {fast: cli.flags.fast}).then(function (res) {
 	if (cli.flags.pretty) {

--- a/cli.js
+++ b/cli.js
@@ -97,7 +97,7 @@ if (cli.flags.fast) {
 	console.warn('WARNING: using --fast may result in different metrics due to skipped frames');
 }
 
-speedIndex(filePath, {fast: cli.flags.fast}).then(function (res) {
+speedIndex(filePath, {fastMode: cli.flags.fast}).then(function (res) {
 	if (cli.flags.pretty) {
 		return displayPretty(res);
 	}

--- a/cli.js
+++ b/cli.js
@@ -79,6 +79,7 @@ var cli = meow([
 	'',
 	'Options',
 	'  -p, --pretty  Pretty print the output',
+	'  --fast  Skip parsing frames between similar ones',
 	'',
 	'Examples',
 	'  $ speedline ./timeline.json'
@@ -91,7 +92,7 @@ if (cli.input.length !== 1) {
 
 var filePath = path.resolve(process.cwd(), cli.input[0]);
 
-speedIndex(filePath).then(function (res) {
+speedIndex(filePath, {fast: cli.flags.fast}).then(function (res) {
 	if (cli.flags.pretty) {
 		return displayPretty(res);
 	}

--- a/src/frame.js
+++ b/src/frame.js
@@ -108,7 +108,9 @@ function extractFramesFromTimeline(timeline, opts) {
 function frame(imgBuff, ts) {
 	let _histogram = null;
 	let _progress = null;
+	let _isProgressInterpolated = null;
 	let _perceptualProgress = null;
+	let _isPerceptualProgressInterpolated = null;
 	let _parsedImage = null;
 
 	return {
@@ -126,12 +128,14 @@ function frame(imgBuff, ts) {
 			return ts;
 		},
 
-		setProgress: function (progress) {
+		setProgress: function (progress, isInterpolated) {
 			_progress = progress;
+			_isProgressInterpolated = Boolean(isInterpolated);
 		},
 
-		setPerceptualProgress: function (progress) {
+		setPerceptualProgress: function (progress, isInterpolated) {
 			_perceptualProgress = progress;
+			_isPerceptualProgressInterpolated = Boolean(isInterpolated);
 		},
 
 		getImage: function () {
@@ -149,8 +153,16 @@ function frame(imgBuff, ts) {
 			return _progress;
 		},
 
+		isProgressInterpolated: function () {
+			return _isProgressInterpolated;
+		},
+
 		getPerceptualProgress: function () {
 			return _perceptualProgress;
+		},
+
+		isPerceptualProgressInterpolated: function () {
+			return _isPerceptualProgressInterpolated;
 		}
 	};
 }

--- a/src/index.js
+++ b/src/index.js
@@ -30,8 +30,8 @@ function calculateValues(frames, data) {
 module.exports = function (timeline, opts) {
 	return frame.extractFramesFromTimeline(timeline, opts).then(function (data) {
 		const frames = data.frames;
-		speedIndex.calculateVisualProgress(frames);
-		speedIndex.calculatePerceptualProgress(frames);
+		speedIndex.calculateVisualProgress(frames, opts);
+		speedIndex.calculatePerceptualProgress(frames, opts);
 		return calculateValues(frames, data);
 	});
 };

--- a/src/speed-index.js
+++ b/src/speed-index.js
@@ -2,6 +2,7 @@
 
 const imageSSIM = require('image-ssim');
 
+/* BEGIN FAST MODE CONSTANTS - See function doc for explanation */
 const FAST_MODE_ALLOWABLE_CHANGE_MAX = 5;
 const FAST_MODE_ALLOWABLE_CHANGE_MEDIAN = 3;
 const FAST_MODE_ALLOWABLE_CHANGE_MIN = 1;
@@ -9,7 +10,17 @@ const FAST_MODE_ALLOWABLE_CHANGE_MIN = 1;
 const FAST_MODE_CONSTANT = FAST_MODE_ALLOWABLE_CHANGE_MIN;
 const FAST_MODE_MULTIPLIER = FAST_MODE_ALLOWABLE_CHANGE_MAX - FAST_MODE_CONSTANT;
 const FAST_MODE_EXPONENTIATION_COEFFICIENT = Math.log((FAST_MODE_ALLOWABLE_CHANGE_MEDIAN - FAST_MODE_CONSTANT) / FAST_MODE_MULTIPLIER);
+/* END FAST MODE CONSTANTS - See function doc for explanation */
 
+/**
+ * This computes the allowed percentage of change between two frames in fast mode where we won't examine the frames in between them.
+ * It follows an exponential function such that:
+ *  - We allow up to FAST_MODE_ALLOWABLE_CHANGE_MAX percent difference when the frames are ~0s apart.
+ *  - We allow up to FAST_MODE_ALLOWABLE_CHANGE_MEDIAN percent difference when the frames are ~1s apart.
+ *  - We allow up to FAST_MODE_ALLOWABLE_CHANGE_MIN percent difference when the frames are very far apart.
+ *
+ *  f(t) = FAST_MODE_MULTIPLIER * e^(FAST_MODE_EXPONENTIATION_COEFFICIENT * t) + FAST_MODE_CONSTANT
+ */
 function calculateFastModeAllowableChange(elapsedTime) {
 	const elapsedTimeInSeconds = elapsedTime / 1000;
 	const allowableChange = FAST_MODE_MULTIPLIER * Math.exp(FAST_MODE_EXPONENTIATION_COEFFICIENT * elapsedTimeInSeconds) + FAST_MODE_CONSTANT;

--- a/src/speed-index.js
+++ b/src/speed-index.js
@@ -3,13 +3,13 @@
 const imageSSIM = require('image-ssim');
 
 /* BEGIN FAST MODE CONSTANTS - See function doc for explanation */
-const FAST_MODE_ALLOWABLE_CHANGE_MAX = 5;
-const FAST_MODE_ALLOWABLE_CHANGE_MEDIAN = 3;
-const FAST_MODE_ALLOWABLE_CHANGE_MIN = 1;
+const fastModeAllowableChangeMax = 5;
+const fastModeAllowableChangeMedian = 3;
+const fastModeAllowableChangeMin = 1;
 
-const FAST_MODE_CONSTANT = FAST_MODE_ALLOWABLE_CHANGE_MIN;
-const FAST_MODE_MULTIPLIER = FAST_MODE_ALLOWABLE_CHANGE_MAX - FAST_MODE_CONSTANT;
-const FAST_MODE_EXPONENTIATION_COEFFICIENT = Math.log((FAST_MODE_ALLOWABLE_CHANGE_MEDIAN - FAST_MODE_CONSTANT) / FAST_MODE_MULTIPLIER);
+const fastModeConstant = fastModeAllowableChangeMin;
+const fastModeMultiplier = fastModeAllowableChangeMax - fastModeConstant;
+const fastModeExponentiationCoefficient = Math.log((fastModeAllowableChangeMedian - fastModeConstant) / fastModeMultiplier);
 /* END FAST MODE CONSTANTS - See function doc for explanation */
 
 /**
@@ -23,7 +23,7 @@ const FAST_MODE_EXPONENTIATION_COEFFICIENT = Math.log((FAST_MODE_ALLOWABLE_CHANG
  */
 function calculateFastModeAllowableChange(elapsedTime) {
 	const elapsedTimeInSeconds = elapsedTime / 1000;
-	const allowableChange = FAST_MODE_MULTIPLIER * Math.exp(FAST_MODE_EXPONENTIATION_COEFFICIENT * elapsedTimeInSeconds) + FAST_MODE_CONSTANT;
+	const allowableChange = fastModeMultiplier * Math.exp(fastModeExponentiationCoefficient * elapsedTimeInSeconds) + fastModeConstant;
 	return allowableChange;
 }
 
@@ -58,8 +58,8 @@ function calculateFrameProgress(current, initial, target) {
 	return progress;
 }
 
-function calculateProgressBetweenFrames(frames, lowerBound, upperBound, isFast, getProgress, setProgress) {
-	if (!isFast) {
+function calculateProgressBetweenFrames(frames, lowerBound, upperBound, isFastMode, getProgress, setProgress) {
+	if (!isFastMode) {
 		frames.forEach(frame => setProgress(frame, getProgress(frame), false));
 		return;
 	}
@@ -80,8 +80,8 @@ function calculateProgressBetweenFrames(frames, lowerBound, upperBound, isFast, 
 		}
 	} else if (upperBound - lowerBound > 1) {
 		const midpoint = Math.floor((lowerBound + upperBound) / 2);
-		calculateProgressBetweenFrames(frames, lowerBound, midpoint, isFast, getProgress, setProgress);
-		calculateProgressBetweenFrames(frames, midpoint, upperBound, isFast, getProgress, setProgress);
+		calculateProgressBetweenFrames(frames, lowerBound, midpoint, isFastMode, getProgress, setProgress);
+		calculateProgressBetweenFrames(frames, midpoint, upperBound, isFastMode, getProgress, setProgress);
 	}
 }
 
@@ -105,7 +105,7 @@ function calculateVisualProgress(frames, opts) {
 		frames,
 		0,
 		frames.length - 1,
-		opts && opts.fast,
+		opts && opts.fastMode,
 		getProgress,
 		setProgress
 	);
@@ -149,7 +149,7 @@ function calculatePerceptualProgress(frames, opts) {
 		frames,
 		0,
 		frames.length - 1,
-		opts && opts.fast,
+		opts && opts.fastMode,
 		getProgress,
 		setProgress
 	);
@@ -207,6 +207,7 @@ function calculateSpeedIndexes(frames, data) {
 }
 
 module.exports = {
+	calculateFastModeAllowableChange,
 	calculateFrameSimilarity,
 	calculateVisualProgress,
 	calculatePerceptualProgress,

--- a/test/speed-index.js
+++ b/test/speed-index.js
@@ -21,7 +21,7 @@ function calculateVisualProgressFromImages(images = [], delay = 1000) {
 test('fast mode allowable change shrinks over time', t => {
 	t.is(speedIndex.calculateFastModeAllowableChange(0), 5);
 	t.is(speedIndex.calculateFastModeAllowableChange(1000), 3);
-	t.ok(speedIndex.calculateFastModeAllowableChange(10000) - 1 < .005);
+	t.true(speedIndex.calculateFastModeAllowableChange(10000) - 1 < 0.005);
 });
 
 test('frame similarity should reflect SSIM', async t => {

--- a/test/speed-index.js
+++ b/test/speed-index.js
@@ -18,6 +18,12 @@ function calculateVisualProgressFromImages(images = [], delay = 1000) {
 	};
 }
 
+test('fast mode allowable change shrinks over time', t => {
+	t.is(speedIndex.calculateFastModeAllowableChange(0), 5);
+	t.is(speedIndex.calculateFastModeAllowableChange(1000), 3);
+	t.ok(speedIndex.calculateFastModeAllowableChange(10000) - 1 < .005);
+});
+
 test('frame similarity should reflect SSIM', async t => {
 	const data = calculateVisualProgressFromImages([
 		'./assets/frameA.jpg',
@@ -140,8 +146,8 @@ test('speed indexes calculated with --fast', t => {
 	const mockInitialFrame = fs.readFileSync('./assets/frameWhite.jpg');
 	const mockTargetFrame = fs.readFileSync('./assets/frameC.jpg');
 	const mockData = getMockProgressFramesForFast(mockInitialFrame, mockTargetFrame);
-	speedIndex.calculateVisualProgress(mockData.frames, {fast: true});
-	speedIndex.calculatePerceptualProgress(mockData.frames, {fast: true});
+	speedIndex.calculateVisualProgress(mockData.frames, {fastMode: true});
+	speedIndex.calculatePerceptualProgress(mockData.frames, {fastMode: true});
 
 	const indexes = speedIndex.calculateSpeedIndexes(mockData.frames, mockData.data);
 	t.is(Math.floor(indexes.speedIndex), 4360);

--- a/test/speed-index.js
+++ b/test/speed-index.js
@@ -136,6 +136,15 @@ test('speed indexes calculated for realistic trace', async t => {
 	t.is(Math.floor(indexes.perceptualSpeedIndex), 578);
 });
 
+test('speed indexes calculated for realistic trace with --fast', async t => {
+	const data = await frame.extractFramesFromTimeline('./assets/progressive-app-m59.json');
+	speedIndex.calculateVisualProgress(data.frames, {fast: true});
+	speedIndex.calculatePerceptualProgress(data.frames, {fast: true});
+	const indexes = speedIndex.calculateSpeedIndexes(data.frames, data);
+	t.is(Math.floor(indexes.speedIndex), 537);
+	t.is(Math.floor(indexes.perceptualSpeedIndex), 578);
+});
+
 test('speed index starts summing from first paint', async t => {
 	const mockData = getMockProgessFrames();
 	/**


### PR DESCRIPTION
This PR changes the progress calculation to optionally skip frames that are between ones that have similar progress toward the target. When enabled, it speeds up processing by about 40% and has minimal impact when not enabled via the shortcut. This also aligns perceptual progress and visual progress by sharing the same computation code and fixes #48 by virtue of the fact that we can't wait for the global min when we only parse some of the JPEGs.

Timings
```sh
( for i in $(seq 10); do; speedline cnn.json --pretty; done; )  55.15s user 4.63s system 98% cpu 1:00.44 total

( for i in $(seq 10); do; speedline cnn.json --pretty --fast; done; )  34.28s user 3.32s system 99% cpu 37.737 total
```

1 - (34/55) = ~38%


Open Questions
* Expose the direct threshold value as the option or keep as binary? If so, name? `similarProgressThreshold`?
