### PR TITLE
Use new babar and set the grid color to grey

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -54,11 +54,11 @@ function displayPretty(res) {
 	var baseTs = res.frames[0].getTimeStamp();
 
 	var progress = res.frames.map(frame => [frame.getTimeStamp() - baseTs, frame.getProgress()]);
-	console.log(babar(progress));
+	console.log(babar(progress, {grid: 'grey'}));
 
 	console.log(bold('Histogram perceptual visual progress:'));
 	var perceptualProgress = res.frames.map(frame => [frame.getTimeStamp() - baseTs, frame.getPerceptualProgress()]);
-	console.log(babar(perceptualProgress));
+	console.log(babar(perceptualProgress, {grid: 'grey'}));
 }
 
 function handleError(err) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "performance"
   ],
   "dependencies": {
-    "babar": "0.0.3",
+    "babar": "0.2.0",
     "image-ssim": "^0.2.0",
     "jpeg-js": "^0.1.2",
     "loud-rejection": "^1.6.0",


### PR DESCRIPTION
With the new version of babar we can now have a color for the grid, useful for black term.
The half ▄ allows to have nicer graph and more precision on the output.