### PR TITLE
add ts typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,17 +3,13 @@
   "version": "1.3.1",
   "description": "Get the speed index from chrome dev tool timeline files",
   "license": "MIT",
-  "repository": "pmdartus/speedline",
-  "author": {
-    "name": "Pierre-Marie Dartus",
-    "email": "dartus.pierremarie@gmail.com",
-    "url": "github.com/pmdartus"
-  },
+  "repository": "paulirish/speedline",
   "bin": "cli.js",
   "main": "src",
   "engines": {
     "node": ">=5.0"
   },
+  "types": "speedline.d.ts",
   "scripts": {
     "test": "xo && ava"
   },
@@ -26,6 +22,7 @@
     "performance"
   ],
   "dependencies": {
+    "@types/node": "*",
     "babar": "0.2.0",
     "image-ssim": "^0.2.0",
     "jpeg-js": "^0.1.2",

--- a/speedline.d.ts
+++ b/speedline.d.ts
@@ -1,0 +1,81 @@
+/// <reference types="node" />
+
+interface TraceEvent {
+  name: string;
+  args: {
+    data?: {
+      url?: string
+    };
+  };
+  tid: number;
+  ts: number;
+  dur: number;
+}
+
+type IncludeType = 'all' | 'speedIndex' | 'perceptualSpeedIndex';
+
+/**
+ * @param trace Trace file location or an array of traceEvents.
+ */
+declare function Speedline<I extends IncludeType = 'all'>(trace: string|TraceEvent[], opts: Speedline.Options<I>): Promise<Speedline.Output<I>>;
+
+declare namespace Speedline {
+  interface Options<I extends IncludeType = 'all'> {
+    /**
+     * Provides the baseline timeStamp, typically navigationStart. Must be a monotonic clock
+     * timestamp that matches the trace. E.g. `speedline('trace.json', {timeOrigin: 103205446186})`
+     */
+    timeOrigin?: number;
+    /**
+     * If the elapsed time and difference in similarity between two screenshots are small,
+     * fastMode will skip decoding and evaluating the frames between them.
+     */
+    fastMode?: boolean;
+    /**
+     * Specifies which speed indexes to compute, can be one of
+     * `all|speedIndex|perceptualSpeedIndex`. Defaults to `all`.
+     */
+    include?: I;
+  }
+
+  interface Output<I extends (IncludeType | 'unknown') = 'unknown'> {
+    /** Recording start timestamp. */
+    beginning: number;
+    /** Recording end timestamp. */
+    end: number;
+    /** Duration before the first visual change, in ms. */
+    first: number;
+    /** Duration before the last visual change, in ms. */
+    complete: number;
+    /** Timeline recording duration, in ms. */
+    duration: number;
+
+    /** Array of all the frames extracted from the timeline. */
+    frames: Array<{
+      /**
+       * @return The frame histogram. Note that light pixels informations are removed
+       * from the histogram for better speed index calculation accuracy.
+       */
+      getHistogram(): number[][];
+      /** @return The frame timestamp. */
+      getTimeStamp(): number;
+      /** @return The frame content. */
+      getImage(): Buffer;
+      setProgress(progress: number, isInterpolated: boolean): void;
+      setPerceptualProgress(progress: number, isInterpolated: boolean): void;
+      /** @return The frame visual progress. */
+      getProgress(): number;
+      /** @return The frame perceptual visual progress. */
+      getPerceptualProgress(): number;
+      isProgressInterpolated(): boolean;
+      isPerceptualProgressInterpolated(): boolean;
+    }>;
+
+    /** The Speed Index for the trace. Defined if opts.include was 'all' (default) or 'speedIndex'. */
+    speedIndex: I extends 'all'|'speedIndex' ? number : (number | undefined);
+    /** The Perceptual Speed Index for the trace. Defined if opts.include was 'all' (default) or 'perceptualSpeedIndex'. */
+    perceptualSpeedIndex: I extends 'all'|'perceptualSpeedIndex' ? number : (number | undefined);
+  }
+}
+
+export = Speedline;

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,6 +37,10 @@
     ansi-styles "^2.2.1"
     esutils "^2.0.2"
 
+"@types/node@*":
+  version "8.10.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.11.tgz#971ea8cb91adbe0b74e3fbd867dec192d5893a5f"
+
 abbrev@1:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"


### PR DESCRIPTION
updated version of #63

This d.ts file types `output.speedIndex` and `output.perceptualSpeedIndex` based on the `opts.include` value. 

So for instance:
```ts
const si = await speedline([...], { timeOrigin: 5 , include: 'speedIndex'});
const si: number = si.speedIndex; // good, it's a number
const psi: number = si.perceptualSpeedIndex; // Error:
// Type 'number | undefined' is not assignable to type 'number'.
```

```ts
const all = await speedline([...]); // `include` defaults to `all`
const si: number = all.speedIndex; // good
const psi: number = all.perceptualSpeedIndex; // good
```

if somehow you end up with a speedline output that can't have its output shape inferred from the `speedline()` call (maybe it was passed into a function just as a `speedline.Output`), the properties both default to the optional `number | undefined` state:

```ts
declare var unknown: speedline.Output;
const si: number = unknown.speedIndex; // Error, need to check for undefined first
const psi: number = unknown.perceptualSpeedIndex; // Error, could be undefined
```