### PR TITLE
add jsdoc types

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -12,6 +12,7 @@ const OUTPUT_GREEN = '\x1b[32m';
 const OUTPUT_BOLD = '\x1b[1m';
 const OUTPUT_RESET = '\x1b[22m\x1b[39m';
 
+/** @param {speedIndex.Output<'all'|'speedIndex'|'perceptualSpeedIndex'>} res */
 function display(res) {
 	const startTs = res.beginning;
 	const visualProgress = res.frames.map(frame => {
@@ -37,8 +38,11 @@ function display(res) {
 	console.log(log);
 }
 
+/** @param {speedIndex.Output<'all'>} res */
 function displayPretty(res) {
+	/** @param {string} content */
 	const green = (content) => OUTPUT_GREEN + content + OUTPUT_RESET;
+	/** @param {string} content */
 	const bold = (content) => OUTPUT_BOLD + content + OUTPUT_RESET;
 
 	console.log([
@@ -61,6 +65,7 @@ function displayPretty(res) {
 	console.log(babar(perceptualProgress, {grid: 'grey'}));
 }
 
+/** @param {Error} err */
 function handleError(err) {
 	console.error(err.message);
 	console.log(Object.keys(err));

--- a/core/lib/frame.js
+++ b/core/lib/frame.js
@@ -8,7 +8,7 @@ const jpeg = require('jpeg-js');
  * @typedef {import('../speedline').Options<IncludeType>} Options
  * @typedef {import('../speedline').TraceEvent} TraceEvent
  * @typedef {import('../speedline').Output['frames'][number]} Frame
- * @typedef {{data: Buffer, width: number, height: number}} ImageData
+ * @typedef {import('jpeg-js').RawImageData<Buffer>} ImageData
  */
 
 /**

--- a/core/lib/frame.js
+++ b/core/lib/frame.js
@@ -3,20 +3,41 @@
 const fs = require('fs');
 const jpeg = require('jpeg-js');
 
+/**
+ * @typedef {import('../speedline').IncludeType} IncludeType
+ * @typedef {import('../speedline').Options<IncludeType>} Options
+ * @typedef {import('../speedline').TraceEvent} TraceEvent
+ * @typedef {import('../speedline').Output['frames'][number]} Frame
+ * @typedef {{data: Buffer, width: number, height: number}} ImageData
+ */
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @param {number} channel
+ * @param {number} width
+ * @param {Buffer} buff
+ */
 function getPixel(x, y, channel, width, buff) {
 	return buff[(x + y * width) * 4 + channel];
 }
 
+/**
+ * @param {number} i
+ * @param {number} j
+ * @param {ImageData} img
+ */
 function isWhitePixel(i, j, img) {
 	return getPixel(i, j, 0, img.width, img.data) >= 249 &&
 			getPixel(i, j, 1, img.width, img.data) >= 249 &&
 			getPixel(i, j, 2, img.width, img.data) >= 249;
 }
 
+/** @param {ImageData} img */
 function convertPixelsToHistogram(img) {
 	const createHistogramArray = function () {
-		const ret = new Array(256);
-		for (let i = 0; i < ret.length; i++) {
+		const ret = [];
+		for (let i = 0; i < 256; i++) {
 			ret[i] = 0;
 		}
 		return ret;
@@ -48,12 +69,13 @@ function convertPixelsToHistogram(img) {
 	return histograms;
 }
 
+/** @param {Array<Frame>} frames */
 function synthesizeWhiteFrame(frames) {
 	const firstImageData = jpeg.decode(frames[0].getImage());
 	const width = firstImageData.width;
 	const height = firstImageData.height;
 
-	const frameData = new Buffer(width * height * 4);
+	const frameData = Buffer.alloc(width * height * 4);
 	let i = 0;
 	while (i < frameData.length) {
 		frameData[i++] = 0xFF; // red
@@ -71,23 +93,32 @@ function synthesizeWhiteFrame(frames) {
 }
 
 const screenshotTraceCategory = 'disabled-by-default-devtools.screenshot';
+
+/**
+ * @param {string|Array<TraceEvent>|{traceEvents: Array<TraceEvent>}} timeline
+ * @param {Options} opts
+ */
 function extractFramesFromTimeline(timeline, opts) {
 	opts = opts || {};
+	/** @type {Array<TraceEvent>|{traceEvents: Array<TraceEvent>}} */
 	let trace;
-	trace = typeof timeline === 'string' ? fs.readFileSync(timeline, 'utf-8') : timeline;
+	timeline = typeof timeline === 'string' ? fs.readFileSync(timeline, 'utf-8') : timeline;
 	try {
-		trace = typeof trace === 'string' ? JSON.parse(trace) : trace;
+		trace = typeof timeline === 'string' ? JSON.parse(timeline) : timeline;
 	} catch (e) {
 		throw new Error('Speedline: Invalid JSON' + e.message);
 	}
+	/** @type {Array<TraceEvent>} */
 	let events = trace.traceEvents || trace;
 	events = events.sort((a, b) => a.ts - b.ts).filter(e => e.ts !== 0);
 
 	const startTs = (opts.timeOrigin || events[0].ts) / 1000;
 	const endTs = events[events.length - 1].ts / 1000;
 
+	/** @type {?string} */
 	let lastFrame = null;
 	const rawScreenshots = events.filter(e => e.cat.includes(screenshotTraceCategory) && e.ts >= startTs * 1000);
+	/** @type {Array<Frame>} */
 	const uniqueFrames = rawScreenshots.map(function (evt) {
 		const base64img = evt.args && evt.args.snapshot;
 		const timestamp = evt.ts / 1000;
@@ -97,7 +128,7 @@ function extractFramesFromTimeline(timeline, opts) {
 		}
 
 		lastFrame = base64img;
-		const imgBuff = new Buffer(base64img, 'base64');
+		const imgBuff = Buffer.from(base64img, 'base64');
 		return frame(imgBuff, timestamp);
 	}).filter(Boolean);
 
@@ -116,12 +147,23 @@ function extractFramesFromTimeline(timeline, opts) {
 	return Promise.resolve(data);
 }
 
+/**
+ * @param {Buffer} imgBuff
+ * @param {number} ts
+ * @return {Frame}
+ */
 function frame(imgBuff, ts) {
+	/** @type {?Array<Array<number>>} */
 	let _histogram = null;
+	/** @type {?number} */
 	let _progress = null;
+	/** @type {?boolean} */
 	let _isProgressInterpolated = null;
+	/** @type {?number} */
 	let _perceptualProgress = null;
+	/** @type {?boolean} */
 	let _isPerceptualProgressInterpolated = null;
+	/** @type {?ImageData} */
 	let _parsedImage = null;
 
 	return {

--- a/core/lib/index.js
+++ b/core/lib/index.js
@@ -3,6 +3,16 @@
 const frame = require('./frame');
 const speedIndex = require('./speed-index');
 
+/**
+ * @typedef {import('../speedline').TraceEvent} TraceEvent
+ * @typedef {import('../speedline').IncludeType} IncludeType
+ * @typedef {import('../speedline').Output['frames'][number]} Frame
+ */
+
+/**
+ * @param {Array<Frame>} frames
+ * @param {{startTs: number, endTs: number}} data
+ */
 function calculateValues(frames, data) {
 	const indexes = speedIndex.calculateSpeedIndexes(frames, data);
 	const duration = Math.floor(data.endTs - data.startTs);
@@ -21,6 +31,7 @@ function calculateValues(frames, data) {
 	};
 }
 
+/** @type {{All: 'all', pSI: 'perceptualSpeedIndex', SI: 'speedIndex'}} */
 const Include = {
 	All: 'all',
 	pSI: 'perceptualSpeedIndex',
@@ -29,9 +40,10 @@ const Include = {
 
 /**
  * Retrieve speed index informations
- * @param  {string|Array|DevtoolsTimelineModel} timeline
- * @param  {?Object} opts
- * @return {Promise} resolving with an object containing the speed index informations
+ * @template {IncludeType} I
+ * @param {string|Array<TraceEvent>} timeline
+ * @param {import('../speedline').Options<I>} opts
+ * @return {Promise<import('../speedline').Output<I>>}
  */
 module.exports = function (timeline, opts) {
 	const include = opts && opts.include || Include.All;

--- a/core/speedline.d.ts
+++ b/core/speedline.d.ts
@@ -1,25 +1,13 @@
 /// <reference types="node" />
 
-interface TraceEvent {
-  name: string;
-  args: {
-    data?: {
-      url?: string
-    };
-  };
-  tid: number;
-  ts: number;
-  dur: number;
-}
-
-type IncludeType = 'all' | 'speedIndex' | 'perceptualSpeedIndex';
-
 /**
  * @param trace Trace file location or an array of traceEvents.
  */
-declare function Speedline<I extends IncludeType = 'all'>(trace: string|TraceEvent[], opts: Speedline.Options<I>): Promise<Speedline.Output<I>>;
+declare function Speedline<I extends Speedline.IncludeType = 'all'>(trace: string|Speedline.TraceEvent[], opts: Speedline.Options<I>): Promise<Speedline.Output<I>>;
 
 declare namespace Speedline {
+  type IncludeType = 'all' | 'speedIndex' | 'perceptualSpeedIndex';
+
   interface Options<I extends IncludeType = 'all'> {
     /**
      * Provides the baseline timeStamp, typically navigationStart. Must be a monotonic clock
@@ -36,6 +24,20 @@ declare namespace Speedline {
      * `all|speedIndex|perceptualSpeedIndex`. Defaults to `all`.
      */
     include?: I;
+  }
+
+  interface TraceEvent {
+    name: string;
+    cat: string;
+    args: {
+      data?: {
+        url?: string
+      };
+      snapshot?: string;
+    };
+    tid: number;
+    ts: number;
+    dur: number;
   }
 
   interface Output<I extends (IncludeType | 'unknown') = 'unknown'> {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     "meow": "^3.7.0"
   },
   "devDependencies": {
+    "@types/jpeg-js": "^0.3.0",
+    "@types/loud-rejection": "^1.6.0",
+    "@types/meow": "^4.0.1",
+    "typescript": "3.0.3",
     "xo": "^0.14.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
   },
   "include": [
     "./cli.js",
-    "core/lib/index.js"
+    "core/lib/*.js"
   ],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "commonjs",
+    "target": "ES2017",
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+
+    "typeRoots": [
+      "@types",
+    ],
+    "diagnostics": true
+  },
+  "include": [
+    "./cli.js",
+    "core/lib/index.js"
+  ],
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,32 @@
 # yarn lockfile v1
 
 
+"@types/jpeg-js@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@types/jpeg-js/-/jpeg-js-0.3.0.tgz#5971f0aa50900194e9565711c265c10027385e89"
+  dependencies:
+    "@types/node" "*"
+
+"@types/loud-rejection@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@types/loud-rejection/-/loud-rejection-1.6.0.tgz#a24a01076472fe159af2f5729ca68b28ba5e4559"
+
+"@types/meow@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/meow/-/meow-4.0.1.tgz#cb80b9f0b8695df7ac15f0165585bcd2d0a6d94f"
+  dependencies:
+    "@types/minimist-options" "*"
+
+"@types/minimist-options@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/minimist-options/-/minimist-options-3.0.0.tgz#0dabe91d07e21c9b3fe9614ca862aab202566eb5"
+  dependencies:
+    "@types/minimist" "*"
+
+"@types/minimist@*":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
+
 "@types/node@*":
   version "8.10.11"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.11.tgz#971ea8cb91adbe0b74e3fbd867dec192d5893a5f"
@@ -1478,6 +1504,10 @@ type-check@~0.3.2:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
 
 unzip-response@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
while changing code I kept having to manually trace arguments up three or four levels of function calls to figure out what was being passed in. This adds jsdoc types to make it so you know locally what everything is :)

Functional code changes are minimal, an array initialization, a local variable name, and switching off of `new Buffer()`. Note that the tsc type checking doesn't actually pass; we'll have to figure out the optional types used in a bunch of places on a different day :)