### PR TITLE
chore: update jpeg-js to 0.4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '5'
+  - "8"
 install:
   - yarn install-all
 script:

--- a/core/package.json
+++ b/core/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/paulirish/speedline",
   "main": "lib",
   "engines": {
-    "node": ">=5.0"
+    "node": ">=8.0"
   },
   "scripts": {
     "lint": "xo",
@@ -25,7 +25,7 @@
   "dependencies": {
     "@types/node": "*",
     "image-ssim": "^0.2.0",
-    "jpeg-js": "^0.1.2"
+    "jpeg-js": "^0.4.1"
   },
   "devDependencies": {
     "ava": "^0.19.1",

--- a/core/yarn.lock
+++ b/core/yarn.lock
@@ -1963,9 +1963,10 @@ jest-validate@^19.0.2:
     leven "^2.0.0"
     pretty-format "^19.0.0"
 
-jpeg-js@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.1.2.tgz#135b992c0575c985cfa0f494a3227ed238583ece"
+jpeg-js@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.1.tgz#937a3ae911eb6427f151760f8123f04c8bfe6ef7"
+  integrity sha512-jA55yJiB5tCXEddos8JBbvW+IMrqY0y1tjjx9KNVtA+QPmu7ND5j0zkKopClpUTsaETL135uOM2XfcYG4XRjmw==
 
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "bin": "cli.js",
   "main": "core/lib",
   "engines": {
-    "node": ">=5.0"
+    "node": ">=8.0"
   },
   "types": "core/speedline.d.ts",
   "scripts": {
@@ -28,7 +28,7 @@
     "@types/node": "*",
     "babar": "0.2.0",
     "image-ssim": "^0.2.0",
-    "jpeg-js": "^0.1.2",
+    "jpeg-js": "^0.4.1",
     "loud-rejection": "^1.6.0",
     "meow": "^3.7.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -914,9 +914,10 @@ isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
-jpeg-js@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.1.2.tgz#135b992c0575c985cfa0f494a3227ed238583ece"
+jpeg-js@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.1.tgz#937a3ae911eb6427f151760f8123f04c8bfe6ef7"
+  integrity sha512-jA55yJiB5tCXEddos8JBbvW+IMrqY0y1tjjx9KNVtA+QPmu7ND5j0zkKopClpUTsaETL135uOM2XfcYG4XRjmw==
 
 js-tokens@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Motivation: prevent nagging security audits about vulnerabilities, stay current.

It's highly unlikely that Chromium creates JPEGs that are malicious but it's certainly possible that someone tries to use speedline on user input with malicious JPEGs, so probably worth upgrading for the security vuln.

The breaking changes in addition to the memory limit caps are loss of support for older node and API changes to the way options are passed in to decode. None of those applied here other than node support.

BREAKING CHANGE: Drop support for Node <8

will require a major version rev :(